### PR TITLE
Auto-Populate Account Details + Delete Restaurant

### DIFF
--- a/frontend/second-bite-vite-frontend/src/components/account_info/OwnerInfo.jsx
+++ b/frontend/second-bite-vite-frontend/src/components/account_info/OwnerInfo.jsx
@@ -8,8 +8,20 @@ import { AppContext } from "../../context/AppContext"
 
 const OwnerInfo = () => {
     const navigate = useNavigate()
-    const {setIsAddRestaurantModal} =  useContext(AppContext)
+    const {base_url, setIsAddRestaurantModal} =  useContext(AppContext)
 
+    // State variables
+    const [username, setUsername] = useState('')
+    const [password, setPassword] = useState('')
+    const [confirmPassword, setConfirmPassword] = useState('')
+    const [streetAddress, setStreetAddress] = useState('')
+    const [city, setCity] = useState('')
+    const [postal_code, setPostalCode] = useState('')
+    const [state, setState] = useState('')
+    const [country, setCountry] = useState('')
+    const [owned_restaurants, setOwnedRestaurants] = useState([]) // Array of owned restaurants
+
+    // Missing fields error messages
     const [username_msg, setUsernameMsg] = useState('')
     const [password_msg, setPasswordMsg] = useState('')
     const [confirm_password_msg, setConfirmPasswordMsg] = useState('')
@@ -18,10 +30,38 @@ const OwnerInfo = () => {
     const [postal_code_msg, setPostalCodeMsg] = useState('')
     const [state_msg, setStateMsg] = useState('')
     const [country_msg, setCountryMsg] = useState('')
-    const [selected_restaurant, setSelectedRestaurant] = useState('Select Your Restaurant:')
+
+    const [selected_restaurant, setSelectedRestaurant] = useState({})
 
     const form_ref = useRef();
     // TODO: Pre-populate with existing account info
+
+    const getOwnerInfo = async () => {
+        // Fetch owner info from DB
+        const response = await fetch(base_url + '/owner', {
+            method: 'GET',
+            credentials: 'include'
+        })
+        const res_json = await response.json()
+        if(!response.ok) {
+            console.error(res_json)
+        }
+        // Set state variables
+        setUsername(res_json.username)
+        setPassword(res_json.password)
+        setConfirmPassword(res_json.password)
+        setStreetAddress(res_json.address.street_address)
+        setCity(res_json.address.city)
+        setPostalCode(res_json.address.postal_code)
+        setState(res_json.address.state)
+        setCountry(res_json.address.country)
+        setOwnedRestaurants(res_json.restaurants)
+    }
+
+    useEffect(() => {
+        getOwnerInfo()
+    }, [])
+
 
     // Handlers
     const handleAccountReturn = () => {
@@ -33,53 +73,60 @@ const OwnerInfo = () => {
     const handleAddRestaurant = () => {
         setIsAddRestaurantModal(true)
     }
-    const handleDeleteRestaurant = () => {
-        
+    const handleDeleteRestaurant = async () => {
+        if(selected_restaurant) {
+            const response = await fetch(base_url + `/restaurant/${selected_restaurant.restaurant_id}`, {
+                method: 'DELETE',
+                credentials: 'include',
+            })
+            const res_json = await response.json()
+            console.log(res_json)
+            await getOwnerInfo()
+            setSelectedRestaurant({})
+        }
     }
-
-    useEffect(() => {
-
-    }, [])
+    const handleAccountInfoSave = () => {
+        event.preventDefault()
+    }
 
     return (
         <section className="account_info">
-            <form className="account_info_form">
+            <form className="account_info_form" onSubmit={handleAccountInfoSave}>
                 <button type="button" className="account_return_btn" onClick={handleAccountReturn}>←</button>
                 <h2 className="text-2xl font-bold mt-6 mb-4" id="account_info_title">Edit Personal info</h2>
-
 
 
                 <section className="account_entries">
                     {/* Username, Password, Re-Enter Password */}
                     <section className="account_entry">
                         <p className="auth_text">Username:</p>
-                        <input type="text" name="owner_edit_username" className="account_input" placeholder={username_msg} />
+                        <input type="text" name="owner_edit_username" className="account_input" placeholder={username_msg} value={username} onChange={event => setUsername(event.target.value)}/>
                     </section>
                     <section className="account_entry">
                         <p className="auth_text">Password:</p>
-                        <input type="text" name="owner_edit_password" className="account_input" placeholder={password_msg} />
+                        <input type="password" name="owner_edit_password" className="account_input" placeholder={password_msg} value={password} onChange={event => setPassword(event.target.value)}/>
                     </section>
                     <section className="account_entry">
                         <p className="auth_text">Confirm Password:</p>
-                        <input type="text" name="owner_edit_confirm_password" className="account_input" placeholder={confirm_password_msg} />
+                        <input type="password" name="owner_edit_confirm_password" className="account_input" placeholder={confirm_password_msg} value={confirmPassword} onChange={event => setConfirmPassword(event.target.value)}/>
                     </section>      
 
                     <section className="location_account_entries">
                         <section className="location_account_entry">
                             <p className="location_auth_text">Street Address:</p>
-                            <input type="text" name="owner_edit_street_address" className="account_input" placeholder={street_address_msg} />
+                            <input type="text" name="owner_edit_street_address" className="account_input" placeholder={street_address_msg} value={streetAddress} onChange={event => setStreetAddress(event.target.value)}/>
                         </section>
                         <section className="location_account_entry">
                             <p className="location_auth_text">City:</p>
-                            <input type="text" name="owner_edit_city" className="account_input" placeholder={city_msg} />
+                            <input type="text" name="owner_edit_city" className="account_input" placeholder={city_msg} value={city} onChange={event => setCity(event.target.value)}/>
                         </section>
                         <section className="location_account_entry">
                             <p className="location_auth_text">Postal Code:</p>
-                            <input type="text" name="owner_edit_postal_code" className="account_input" placeholder={postal_code_msg} />
+                            <input type="text" name="owner_edit_postal_code" className="account_input" placeholder={postal_code_msg} value={postal_code} onChange={event => setPostalCode(event.target.value)}/>
                         </section>
                         <section className="location_account_entry">
                             <p className="location_auth_text">State:</p>
-                            <select name="owner_edit_state" className="account_input">
+                            <select name="owner_edit_state" className="account_input" value={state} onChange={event => setState(event.target.value)}>
                                 <option value="none">{state_msg || 'Select a State:'}</option>
                                 {states.map((state) => (
                                     <option key={state.abbreviation} value={state.abbreviation}>
@@ -90,7 +137,7 @@ const OwnerInfo = () => {
                         </section>
                         <section className="location_account_entry">
                             <p className="location_auth_text">Country:</p>
-                            <select name="owner_edit_country" className="account_input">
+                            <select name="owner_edit_country" className="account_input" value={country} onChange={event => setCountry(event.target.value)}>
                                 <option value="none">{country_msg || 'Select a Country:'}</option>
                                 <option value="US">United States</option>
                             </select>
@@ -101,7 +148,7 @@ const OwnerInfo = () => {
                     <section className="owner_btns self-start">
                         <Menu as="div" className="relative inline-block text-left self-start">
                         <MenuButton className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset hover:bg-gray-50">
-                            {selected_restaurant}
+                            {selected_restaurant.name || "Select a Restaurant"}
                             <ChevronDownIcon aria-hidden="true" className="-mr-1 h-5 w-5 text-gray-400" />
                         </MenuButton>
                         <MenuItems
@@ -111,30 +158,30 @@ const OwnerInfo = () => {
                                         data-enter:duration-100 data-enter:ease-out
                                         data-leave:duration-75 data-leave:ease-in"
                         >
-                            <MenuItem onClick={() => {handleRestaurantSelect('Mezze Cafe')}}>
+                            <MenuItem key={-1} onClick={() => {handleRestaurantSelect({})}}>
                             {({ active }) => (
                                 <a
                                 href="#"
-                                className={`block px-4 py-2 text-sm text-gray-600 ${
-                                    active ? 'bg-gray-100 text-gray-900' : ''
-                                }`}
+                                className={`block px-4 py-2 text-sm text-gray-600 ${active ? 'bg-gray-100 text-gray-900' : ''}`}
                                 >
-                                Mezze Cafe
+                                Select a Restaurant:
                                 </a>
                             )}
                             </MenuItem>
-                            <MenuItem onClick={() => {handleRestaurantSelect('Bento Box')}}>
-                            {({ active }) => (
-                                <a
-                                href="#"
-                                className={`block px-4 py-2 text-sm text-gray-600 ${
-                                    active ? 'bg-gray-100 text-gray-900' : ''
-                                }`}
-                                >
-                                Bento Box
-                                </a>
-                            )}
-                            </MenuItem>
+                            {
+                                owned_restaurants.map((restaurant) => (
+                                    <MenuItem key={restaurant.restaurant_id} onClick={() => {handleRestaurantSelect(restaurant)}}>
+                                    {({ active }) => (
+                                        <a
+                                        href="#"
+                                        className={`block px-4 py-2 text-sm text-gray-600 ${active ? 'bg-gray-100 text-gray-900' : ''}`}
+                                        >
+                                        {restaurant.name}
+                                        </a>
+                                    )}
+                                    </MenuItem>
+                                ))
+                            }
                         </MenuItems>
                         </Menu>  
                         <button type="button" className="add_restaurant_btn" onClick={handleAddRestaurant}>+</button>
@@ -150,6 +197,5 @@ const OwnerInfo = () => {
         </section>
     )
 }
-
 
 export default OwnerInfo


### PR DESCRIPTION
### Before and After Product Change

Before 
- UI for account details page

After
See This Pull Request Section


### Context
In order for users to edit their account information, the backend infrastructure needed to be set up. Moreover, if a restaurant goes out of business, the owner should be able to delete that restaurant so that consumers no longer view it as available and the owner no longer gets analytics for it

### This Pull Request
- Adds backend endpoint for getting account details
- Integrates frontend and backend for populating account details on page load
- Sets up endpoint for deleting a restaurant
- Integrates frontend and backend for deleting an endpoint

### Next Pull Request:
In the next PRs, 
- Complete account details 
- More routing & integration
- TCs